### PR TITLE
Use redirect to replace noindex meta tag

### DIFF
--- a/src/app/courses/courseRanking.tsx
+++ b/src/app/courses/courseRanking.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import rankingDataRaw from "../../../data/data_files/processed/ranking_courses.json";
+import { Ranking, RankingItemRaw } from "../components/Ranking";
+
+const rankingData = JSON.parse(JSON.stringify(rankingDataRaw));
+const rankingItems: RankingItemRaw[] = [];
+
+for (const k in rankingData) {
+    const v = rankingData[k];
+    rankingItems.push({
+        title: k,
+        score: v.course_mean,
+        nr: v.num_response,
+        link: "/courses/" + k.slice(0, 4) + k.slice(5),
+    });
+}
+
+export default function CourseRanking() {
+    const searchParams = useSearchParams();
+    const course_code = searchParams.get("course_code");
+    if (course_code) {
+        window.location.href = "/courses/" + course_code;
+    }
+    else return (
+        <div>
+            <h1 className="hidden">Course Rankings on SFQ Scores</h1>
+            <Ranking items={rankingItems} searchPrompt="Search for courses here..." scoreName="course_mean" />
+        </div>
+    );
+}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,26 +1,12 @@
-import rankingDataRaw from "../../../data/data_files/processed/ranking_courses.json";
-import { Ranking, RankingItemRaw } from "../components/Ranking";
+import { Suspense } from "react";
+import CourseRanking from "./courseRanking";
 
-const rankingData = JSON.parse(JSON.stringify(rankingDataRaw));
-const rankingItems: RankingItemRaw[] = [];
-
-for (const k in rankingData) {
-    const v = rankingData[k];
-    rankingItems.push({
-        title: k,
-        score: v.course_mean,
-        nr: v.num_response,
-        link: "/courses/" + k.slice(0, 4) + k.slice(5),
-    });
-}
-
-export default function CourseRankings() {
+export default function Page() {
     return (
-        <div>
-            <h1 className="hidden">Course Rankings on SFQ Scores</h1>
-            <Ranking items={rankingItems} searchPrompt="Search for courses here..." scoreName="course_mean" />
-        </div>
-    );
+        <Suspense fallback={<div>Loading...</div>}>
+            <CourseRanking />
+        </Suspense>
+    )
 }
 
 export async function generateMetadata() {

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -23,16 +23,10 @@ export default function CourseRankings() {
     );
 }
 
-export async function generateMetadata({ searchParams }: { searchParams: Promise<{ course_code: string }> }) {
-    const courseCode = await searchParams.then(p => p.course_code);
-    const isNoIndex = courseCode ? true : false;
-
+export async function generateMetadata() {
     return {
         title: "HKUST Course Rankings on SFQ Scores - HKUST SFQ Visualizer",
         description: "Rankings of courses based on Student Feedback Questionnaire (SFQ) scores",
-        keywords: ["HKUST", "SFQ", "Rankings", "Course Review", "Teaching Quality"],
-        ...(isNoIndex ? { robots: "noindex" } : {}),
+        keywords: ["HKUST", "SFQ", "Rankings", "Course Review", "Teaching Quality"]
     };
 }
-
-export const runtime = "edge";

--- a/src/app/instructors/instructorRanking.tsx
+++ b/src/app/instructors/instructorRanking.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import rankingDataRaw from "../../../data/data_files/processed/ranking_instructors.json";
+import { Ranking, RankingItemRaw } from "../components/Ranking";
+import { getNameByItsc } from "../utils";
+
+const rankingData = JSON.parse(JSON.stringify(rankingDataRaw));
+const rankingItems: RankingItemRaw[] = [];
+
+for (const k in rankingData) {
+    const v = rankingData[k];
+    rankingItems.push({
+        title: getNameByItsc(k),
+        score: v.instructor_mean,
+        nr: v.num_response,
+        link: "/instructors/" + k,
+    });
+}
+
+export default function InstructorRanking() {
+    const searchParams = useSearchParams();
+    const itsc = searchParams.get("itsc");
+    if (itsc) {
+        window.location.href = "/instructors/" + itsc;
+    }
+    else return (
+        <div>
+            <h1 className="hidden">Instructor Rankings on SFQ Scores</h1>
+            <Ranking items={rankingItems} searchPrompt="Search for instructor here..." scoreName="instructor_mean" />
+        </div>
+    );
+}

--- a/src/app/instructors/page.tsx
+++ b/src/app/instructors/page.tsx
@@ -24,16 +24,10 @@ export default function InstructorRankings() {
     );
 }
 
-export async function generateMetadata({ searchParams }: { searchParams: Promise<{ itsc: string }> }) {
-    const itsc = await searchParams.then(p => p.itsc);
-    const isNoIndex = itsc ? true : false;
-
+export async function generateMetadata() {
     return {
         title: "HKUST Instructor Rankings on SFQ Scores - HKUST SFQ Visualizer",
         description: "Rankings of instructors based on Student Feedback Questionnaire (SFQ) scores",
-        keywords: ["HKUST", "SFQ", "Rankings", "Instructor Evaluation", "Teaching Quality"],
-        ...(isNoIndex ? { robots: "noindex" } : {}),
+        keywords: ["HKUST", "SFQ", "Rankings", "Instructor Evaluation", "Teaching Quality"]
     };
 }
-
-export const runtime = "edge";

--- a/src/app/instructors/page.tsx
+++ b/src/app/instructors/page.tsx
@@ -1,27 +1,12 @@
-import rankingDataRaw from "../../../data/data_files/processed/ranking_instructors.json";
-import { Ranking, RankingItemRaw } from "../components/Ranking";
-import { getNameByItsc } from "../utils";
+import { Suspense } from "react";
+import InstructorRanking from "./instructorRanking";
 
-const rankingData = JSON.parse(JSON.stringify(rankingDataRaw));
-const rankingItems: RankingItemRaw[] = [];
-
-for (const k in rankingData) {
-    const v = rankingData[k];
-    rankingItems.push({
-        title: getNameByItsc(k),
-        score: v.instructor_mean,
-        nr: v.num_response,
-        link: "/instructors/" + k,
-    });
-}
-
-export default function InstructorRankings() {
+export default function Page() {
     return (
-        <div>
-            <h1 className="hidden">Instructor Rankings on SFQ Scores</h1>
-            <Ranking items={rankingItems} searchPrompt="Search for instructor here..." scoreName="instructor_mean" />
-        </div>
-    );
+        <Suspense fallback={<div>Loading...</div>}>
+            <InstructorRanking />
+        </Suspense>
+    )
 }
 
 export async function generateMetadata() {


### PR DESCRIPTION
Now urls that look like `/instructors?itsc=desmond` will be redirected to `/instructors/desmond`